### PR TITLE
Modifications to Gradle build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ anuglar2 with es6 support.
 
 ## build & run
 * `$ gradle clean build`
-* `$ gradle npminstall`
-* `$ gradle gulp_build`
 * `$ gradle bootRun`
 * using browser, navigate to`localhost:8080`
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ repositories {
 dependencies {
 	// spring
 	compile('org.springframework.boot:spring-boot-starter-web')
+	// spring dev tools
+	compile("org.springframework.boot:spring-boot-devtools")
 	// google gson
 	compile('com.google.code.gson:gson:2.6.2')
 

--- a/build.gradle
+++ b/build.gradle
@@ -50,8 +50,8 @@ eclipse {
 
 // configure gradle-node-plugin
 node {
-	version = '5.10.1'
-	npmVersion = '3.8.6'
+	version = '5.11.0'
+	npmVersion = '3.8.7'
 	download = true
 	workDir = file("${project.projectDir}/src/main/web/node")
 	nodeModulesDir = file("${project.projectDir}/src/main/web")

--- a/build.gradle
+++ b/build.gradle
@@ -71,3 +71,7 @@ task wrapper(type: Wrapper) {
 bootRun {
 	addResources = true
 }
+
+// build front-end before making jar
+processResources.dependsOn npmInstall
+npmInstall.finalizedBy gulp_build


### PR DESCRIPTION
I have noticed that the built .jar file does not contain any front-end content when building for the first time.

I have added `npmInstall` and `gulp_build` to the Gradle build process, so now these steps are unnecessary; moreover, you can also run the app with `java -jar`.