### PR TITLE
Output generated resources into subdirectory of /build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ Thumbs.db
 .metadata/
 target/
 
+# IntelliJ Generated
+.idea
+
 # Front End Dependency Generated
 src/main/web/.sass-cache/
 src/main/web/bower_components/
@@ -43,4 +46,3 @@ src/main/web/scss/.tmp/
 src/main/web/js/lib/
 src/main/web/typings/
 src/main/webapp/resources/
-src/main/resources/static/

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,14 @@ eclipse {
 	}
 }
 
+def generatedWebResources = "$buildDir/generated-web-resources"
+
+sourceSets {
+	main {
+		output.dir(generatedWebResources, builtBy: 'gulp_build')
+	}
+}
+
 // configure gradle-node-plugin
 node {
 	version = '6.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -85,3 +85,10 @@ bootRun {
 // build front-end before making jar
 processResources.dependsOn npmInstall
 npmInstall.finalizedBy gulp_build
+
+clean.doFirst {
+	final def webDir = "${rootDir}/src/main/web/"
+	delete "${webDir}/node/"
+	delete "${webDir}/node_modules/"
+	delete "${webDir}/typings/"
+}

--- a/src/main/web/gulpfile.js
+++ b/src/main/web/gulpfile.js
@@ -8,7 +8,7 @@ var ts = require('gulp-typescript');
 var tsProject = ts.createProject('tsconfig.json', {typescript: require('typescript')});
 
 // vars
-var staticDir = '../resources/static/';
+var staticDir = '../../../build/generated-web-resources/static/';
 
 // lib copy
 gulp.task('libcopy', function() {

--- a/src/main/web/tsconfig.json
+++ b/src/main/web/tsconfig.json
@@ -8,7 +8,7 @@
       "experimentalDecorators": true,
       "removeComments": false,
       "noImplicitAny": false,
-      "outDir": "../resources/static/app"
+      "outDir": "../../../build/generated-web-resources/static/app/"
   },
 
   "exclude": [


### PR DESCRIPTION
This PR tunes the gradle configuration in order to output the web resources produced by gulp into `/build/generated-web-resources` which enables to use `/src/main/resources/static` for static resources again (for example image files).