### PR TITLE
Upgrade Angular CLI to 1.0.0-beta.15

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -105,7 +105,7 @@
     "tslint-loader": "^2.1.5",
     "typescript": "2.0.0",
     "url-loader": "^0.5.7",
-    "webpack": "^2.1.0-beta.22",
+    "webpack": "2.1.0-beta.22",
     "webpack-dev-server": "^2.1.0-beta.4",
     "webpack-merge": "^0.14.1"
   }


### PR DESCRIPTION
angular-cli 1.0.0-beta.15 has a dependency on webpack: 2.1.0-beta.22 
whereas angular-cli 1.0.0-beta.14 has a dependency on webpack: ^2.1.0-beta.22). 